### PR TITLE
Fix: Non-player entities can now be denied entry into the end

### DIFF
--- a/src/main/java/net/pm/specifics/mixin/EndPortalMixin.java
+++ b/src/main/java/net/pm/specifics/mixin/EndPortalMixin.java
@@ -1,53 +1,34 @@
 package net.pm.specifics.mixin;
 
 import net.minecraft.block.EndPortalBlock;
-import net.minecraft.entity.Entity;
 import net.minecraft.registry.RegistryKey;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.World;
-import net.minecraft.world.gen.feature.EndPlatformFeature;
 import net.pm.specifics.SpecificsConfig;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
+// When SpecificsConfig.endPortal is true, end portals have vanilla
+// functionality.
+// When SpecificsConfig.endPortal is false, all end portals behave like end
+// portals in the end dimension - sending players to their spawn points and
+// entities to the world spawn point.
 @Mixin(EndPortalBlock.class)
 public class EndPortalMixin {
-    /**
-     * @author Paul Marmet
-     * @reason I'm lazy, and anyway, probably no one will see this code.
-     */
-    @Overwrite
-    public TeleportTarget createTeleportTarget(ServerWorld world, Entity entity, BlockPos pos) {
-        RegistryKey<World> registryKey = world.getRegistryKey() == World.END ? World.OVERWORLD : World.END;
-        ServerWorld serverWorld = world.getServer().getWorld(registryKey);
-        if (serverWorld == null) {
-            return null;
-        } else {
-            boolean bl = SpecificsConfig.endPortal && registryKey == World.END;
-            BlockPos blockPos = bl ? ServerWorld.END_SPAWN_POS : serverWorld.getSpawnPos();
-            Vec3d vec3d = blockPos.toBottomCenterPos();
-            float f = entity.getYaw();
-            if (bl) {
-                EndPlatformFeature.generate(serverWorld, BlockPos.ofFloored(vec3d).down(), true);
-                f = Direction.WEST.asRotation();
-                if (entity instanceof ServerPlayerEntity) {
-                    vec3d = vec3d.subtract(0.0, 1.0, 0.0);
-                }
-            } else {
-                if (entity instanceof ServerPlayerEntity) {
-                    ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity)entity;
-                    return serverPlayerEntity.getRespawnTarget(false, TeleportTarget.NO_OP);
-                }
+    @ModifyVariable(method = "createTeleportTarget", at = @At(value = "STORE"), ordinal = 0)
+    private RegistryKey<World> injected(RegistryKey<World> registryKey) {
+        return SpecificsConfig.endPortal ? registryKey : registryKey == World.END ? World.OVERWORLD : World.END;
+    }
 
-                vec3d = entity.getWorldSpawnPos(serverWorld, blockPos).toBottomCenterPos();
-            }
+    @ModifyVariable(method = "createTeleportTarget", at = @At(value = "STORE"), ordinal = 0)
+    private boolean injected(boolean bl) {
+        return bl && SpecificsConfig.endPortal;
+    }
 
-            return new TeleportTarget(serverWorld, vec3d, entity.getVelocity(), f, entity.getPitch(), TeleportTarget.SEND_TRAVEL_THROUGH_PORTAL_PACKET.then(TeleportTarget.ADD_PORTAL_CHUNK_TICKET));
-        }
+    @ModifyArg(method = "createTeleportTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/TeleportTarget;<init>(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Vec3d;FFLnet/minecraft/world/TeleportTarget$PostDimensionTransition;)V"), index = 5)
+    private TeleportTarget.PostDimensionTransition injected(TeleportTarget.PostDimensionTransition postDimensionTransition) {
+        return SpecificsConfig.endPortal ? postDimensionTransition : TeleportTarget.NO_OP;
     }
 }


### PR DESCRIPTION
When SpecificConfig.endPortal is false, all non-player entities entering any end portal are now sent to the world spawn point instead of being sent to the end dimension when entering an end portal in the overworld.